### PR TITLE
Fix some translations

### DIFF
--- a/locale-patches/config/es.yaml
+++ b/locale-patches/config/es.yaml
@@ -76,6 +76,7 @@ es:
   invites:
     delete: Borrar
     expired: Caducadas
+    prompt: Genera y comparte un enlace con otras personas para darles acceso a owo.cafe
   media_attachments:
     validations:
       images_and_video: No puedes adjuntar un video a un post si ya contiene imágenes

--- a/locale-patches/javascript/es.json
+++ b/locale-patches/javascript/es.json
@@ -132,5 +132,10 @@
 
   "status.replied_to": "En respuesta a {name}",
 
-  "navigation_bar.follow_requests": "Solicitudes de seguimiento"
+  "navigation_bar.follow_requests": "Solicitudes de seguimiento",
+  
+  "compose_form.direct_message_warning_learn_more": "Saber más",
+  "navigation_bar.opened_in_classic_interface": "Las páginas específicas, como publicaciones o cuentas, se abren por defecto en la interfaz web clásica.",
+  "footer.get_app": "Descargar la aplicación",
+  "footer.invite": "Invitar a gente"
 }


### PR DESCRIPTION
Fix Spanish translations for some keys:
- invites.prompt: "Generar y compartir enlaces con otros para conceder acceso a este nodo" -> "Genera y comparte un enlace con otras personas para darles acceso a owo.cafe"
- compose_form.direct_message_warning_learn_more: "Aprender más" -> "Saber más"
- navigation_bar.opened_in_classic_interface: "Publicaciones, cuentas y otras páginas específicas se abren por defecto en la interfaz web clásica." -> "Las páginas específicas, como publicaciones o cuentas, se abren por defecto en la interfaz web clásica."
- footer.get_app: "Obtener la aplicación" -> "Descargar la aplicación"
- footer.invite: "Invitar personas" -> "Invitar a gente"