### PR TITLE
Dockerfile: install node using tarball instead of apt

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,12 @@
       ]
     },
     {
+      "fileMatch": [ "^Dockerfile$" ],
+      "datasourceTemplate": "node-version",
+      "matchStrings": [
+        "ARG NODE_VERSION=\"(?<currentValue>.*)\""
+      ]
+    },    {
       "fileMatch": [ "^Dockerfile.streaming$" ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "ghcr.io/mastodon/mastodon-streaming",

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG MASTODON_VERSION="v4.3.0"
 FROM ghcr.io/mastodon/mastodon:${MASTODON_VERSION} as mastodon
 
 # TODO: locale-patcher could be merged with patcher, but debian does not have yq on their repos yet.
-FROM alpine:latest as locale-patcher
+FROM alpine:3.20.3 as locale-patcher
 
 RUN apk add --update jq yq && \
   mkdir -p /locales/config /locales/javascript && \
@@ -31,7 +31,7 @@ RUN cd /locales/config; \
   done; \
   done
 
-FROM alpine:latest as patcher
+FROM alpine:3.20.3 as patcher
 
 COPY --from=mastodon /opt/mastodon /opt/mastodon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,15 @@ RUN find /patches -type f -name '*.patch' | while read p; do \
 FROM mastodon as rebuilder
 
 USER root
-RUN apt update && apt install -y nodejs npm 
-RUN npm install -g yarn corepack
-RUN corepack enable && corepack prepare --activate && yarn workspaces focus --production @mastodon/mastodon
+ARG TARGETARCH
+ARG NODE_VERSION="v20.17.0"
+ENV NODEARCH=${TARGETARCH/amd/x}
+RUN curl -o- https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-${NODEARCH}.tar.gz | tar -xzC /opt/
+ENV PATH=${PATH}:/opt/node-${NODE_VERSION}-linux-${NODEARCH}/bin/
+RUN npm install -g yarn corepack && \
+  corepack enable && \
+  corepack prepare --activate && \
+  yarn workspaces focus --production @mastodon/mastodon
 
 WORKDIR /opt/mastodon
 


### PR DESCRIPTION
It is way, way faster like this.